### PR TITLE
Enable IPv6 support in ferm firewall

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,12 @@
 # Enable or disable iptables management
 ferm: True
 
+# List of iptables domains enabled in main ferm firewall
+# Currently supported domains:
+#   - 'ip'  - enables IPv4 support (iptables)
+#   - 'ip6' - enables IPv6 support (ip6tables)
+ferm_filter_domains: [ 'ip' ]
+
 # Optional list of CIDR hosts which are not included in ssh port recent filter
 # and won't be blocked by the firewall in case of too many connections.
 # Entries are saved in the local facts on remote hosts.

--- a/templates/etc/ferm/ferm.conf.j2
+++ b/templates/etc/ferm/ferm.conf.j2
@@ -14,7 +14,7 @@
 #       ferm will correctly merge your own configuration with the rest.
 
 
-table filter {
+domain ({{ ferm_filter_domains | unique | join(" ") | default("ip") }}) table filter {
 	chain INPUT {
 {% if ferm_comment is defined and ferm_comment %}
 		mod comment comment "{{ ferm_comment }}" NOP;
@@ -53,7 +53,9 @@ table filter {
 		# Reject everything else
 		protocol udp REJECT reject-with icmp-port-unreachable;
 		protocol tcp REJECT reject-with tcp-reset;
-		REJECT reject-with icmp-proto-unreachable;
+		@if @eq($DOMAIN, ip) {
+			REJECT reject-with icmp-proto-unreachable;
+		}
 	}
 
 	chain OUTPUT {

--- a/templates/etc/ferm/filter-input.d/ansible_controller.conf.j2
+++ b/templates/etc/ferm/filter-input.d/ansible_controller.conf.j2
@@ -33,9 +33,12 @@ Required:
 {% endif %}
 {% set ferm_tpl_local_ansible_controllers_result = ferm_tpl_local_ansible_controllers | sort | unique %}
 {% if ferm_tpl_local_ansible_controllers_result is defined and ferm_tpl_local_ansible_controllers_result %}
-{% for element in ferm_tpl_local_ansible_controllers_result %}
-protocol tcp dport ssh saddr {{ element }} ACCEPT;
-{% endfor %}
+protocol tcp dport ssh {
+	@def $ITEMS = ( @ipfilter( ({{ ferm_tpl_local_ansible_controllers_result | unique | join(" ") }}) ) );
+	@if @ne($ITEMS,"") {
+		saddr $ITEMS ACCEPT;
+	}
+}
 {% else %}
 # ansible_controller is not set, but this shouldn't be here.
 # Something went wrong, re-run the 'ferm' role.

--- a/templates/etc/ferm/filter-input.d/dport_accept.conf.j2
+++ b/templates/etc/ferm/filter-input.d/dport_accept.conf.j2
@@ -17,7 +17,10 @@ Optional:
 
 protocol {{ item.protocol | default('tcp') }} dport ({{ item.dport | join(' ') }}) {
 {% if item.saddr is defined and item.saddr %}
-	saddr ({{ item.saddr | unique | join(' ') }}) ACCEPT;
+	@def $ITEMS = ( @ipfilter( ({{ item.saddr | unique | join(" ") }}) ) );
+	@if @ne($ITEMS,"") {
+		saddr $ITEMS ACCEPT;
+	}
 {% else %}
 {% if item.accept_any is defined and item.accept_any %}
 	ACCEPT;


### PR DESCRIPTION
'ferm' role can now manage 'ip6tables' alongside 'iptables' rules. IPv6
support is currently disabled by default, but can be enabled by adding
'ip6' to list of enabled ferm filter domains. After that, ferm will
manage both tables with correct IP addresses / networks in each.

Make sure that all roles which manage their own ferm rules are updated
to be IPv6-aware before enabling IPv6 support.
