### PR TITLE
Add a way to disable accept rule via variable

### DIFF
--- a/templates/etc/ferm/filter-input.d/dport_accept.conf.j2
+++ b/templates/etc/ferm/filter-input.d/dport_accept.conf.j2
@@ -12,9 +12,13 @@ Optional:
   item.protocol		protocol to configure (tcp, udp)
   item.saddr		list of source addresses to accept
   item.accept_any	accept connections from any IP address if True
+  item.disabled		if True, disable the rule (can be used to toggle rule via variable)
+  item.enabled		if True, enable the rule (can be used to toggle rule via variable)
 
 #}
 
+{% if ((item.disabled is undefined or (item.disabled is defined and not item.disabled)) and
+       (item.enabled is undefined or (item.enabled is defined and item.enabled))) %}
 protocol {{ item.protocol | default('tcp') }} dport ({{ item.dport | join(' ') }}) {
 {% if item.saddr is defined and item.saddr %}
 	@def $ITEMS = ( @ipfilter( ({{ item.saddr | unique | join(" ") }}) ) );
@@ -29,4 +33,7 @@ protocol {{ item.protocol | default('tcp') }} dport ({{ item.dport | join(' ') }
 {% endif %}
 {% endif %}
 }
+{% else %}
+# dport_accept rule has been disabled by a variable
+{% endif %}
 


### PR DESCRIPTION
You can add 'item.disabled: True/False' or 'item.enabled: True/False'
keys to 'dport_accept' iptables rules to be able to enable/disable rules
using Ansible variables.

For example, if you want to open the firewall if a certain list has
a list of IP addresses or networks, you can add a key to your ferm
variables similar to:

  item.enabled: '{{ ipaddr_list }}'

This will automatically enable or disable ferm rules if a specified
variable can be resolved to True or False. You can use 'item.disabled'
key to invert the result - firewall rules will be enabled if the
variable is resolved to False, and vice versa.
