### PR TITLE
Enable IPV6 support in ferm by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ ferm: True
 # Currently supported domains:
 #   - 'ip'  - enables IPv4 support (iptables)
 #   - 'ip6' - enables IPv6 support (ip6tables)
-ferm_filter_domains: [ 'ip' ]
+ferm_filter_domains: [ 'ip', 'ip6' ]
 
 # Optional list of CIDR hosts which are not included in ssh port recent filter
 # and won't be blocked by the firewall in case of too many connections.


### PR DESCRIPTION
From now on, ferm will generate rules for both iptables and ip6tables.
