### PR TITLE
Add support for custom ferm rules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,12 +27,21 @@ ferm_default_policy_forward: 'DROP'
 # Mark packets on invalid ports as bad guys (block port scanning)
 ferm_mark_portscan: False
 
+# List of iptables rules to manage, templates used by these rules are included
+# in templates/etc/ferm/ferm.d/ directory.
+# Additional variables are described below.
+ferm_rules: []
+ferm_group_rules: []
+ferm_host_rules: []
+ferm_dependent_rules: []
+
 # List of iptables INPUT rules to manage, many variables can be found in
 # template files, located in templates/etc/ferm/filter-input.d/ directory.
 # Additional variables are described below.
 ferm_input_list: []
 ferm_input_group_list: []
 ferm_input_host_list: []
+ferm_input_dependent_list: []
 
   #- type: ''             # name of template file to use, required
                           #   format: <type>.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,21 +43,52 @@
     mode: '0644'
   notify: [ 'Restart ferm' ]
 
+- name: Remove ip(6)tables rules if requested
+  file:
+    path: '/etc/ferm/ferm.d/{{ item.weight | default("50") }}_{{ item.filename | default(item.type + "_" + item.dport[0] | default("rules")) }}.conf'
+    state: 'absent'
+  with_flattened:
+    - ferm_rules
+    - ferm_group_rules
+    - ferm_host_rules
+    - ferm_dependent_rules
+  when: ((item.type is defined and item.type) and
+         ((item.dport is defined and item.dport) or (item.rules is defined and item.rules)) and
+         (item.delete is defined and item.delete))
+
+- name: Configure ip(6)tables rules
+  template:
+    src: 'etc/ferm/ferm.d/{{ item.type }}.conf.j2'
+    dest: '/etc/ferm/ferm.d/{{ item.weight | default("50") }}_{{ item.filename | default(item.type + "_" + (item.dport[0] | default("rules"))) }}.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  with_flattened:
+    - ferm_rules
+    - ferm_group_rules
+    - ferm_host_rules
+    - ferm_dependent_rules
+  when: ((item.type is defined and item.type) and
+         ((item.dport is defined and item.dport) or (item.rules is defined and item.rules)) and
+         (item.delete is undefined or (item.delete is defined and not item.delete)))
+
 - name: Remove iptables INPUT rules if requested
   file:
-    path: '/etc/ferm/filter-input.d/{{ item.weight | default("50") }}_{{ item.filename | default(item.type + "_" + item.dport[0]) }}.conf'
+    path: '/etc/ferm/filter-input.d/{{ item.weight | default("50") }}_{{ item.filename | default(item.type + "_" + item.dport[0] | default("rules")) }}.conf'
     state: 'absent'
   with_flattened:
     - ferm_input_list
     - ferm_input_group_list
     - ferm_input_host_list
-  when: ((item.type is defined and item.type) and (item.dport is defined and item.dport)) and
-        (item.delete is defined and item.delete)
+    - ferm_input_dependent_list
+  when: ((item.type is defined and item.type) and
+         ((item.dport is defined and item.dport) or (item.rules is defined and item.rules)) and
+         (item.delete is defined and item.delete))
 
 - name: Configure iptables INPUT rules
   template:
     src: 'etc/ferm/filter-input.d/{{ item.type }}.conf.j2'
-    dest: '/etc/ferm/filter-input.d/{{ item.weight | default("50") }}_{{ item.filename | default(item.type + "_" + item.dport[0]) }}.conf'
+    dest: '/etc/ferm/filter-input.d/{{ item.weight | default("50") }}_{{ item.filename | default(item.type + "_" + (item.dport[0] | default("rules"))) }}.conf'
     owner: 'root'
     group: 'root'
     mode: '0644'
@@ -65,8 +96,10 @@
     - ferm_input_list
     - ferm_input_group_list
     - ferm_input_host_list
-  when: (item.type is defined and item.type and item.dport is defined and item.dport) and
-        (item.delete is undefined or (item.delete is defined and not item.delete))
+    - ferm_input_dependent_list
+  when: ((item.type is defined and item.type) and
+         ((item.dport is defined and item.dport) or (item.rules is defined and item.rules)) and
+         (item.delete is undefined or (item.delete is defined and not item.delete)))
 
 - name: Apply iptables rules if ferm is enabled
   command: ferm --slow /etc/ferm/ferm.conf

--- a/templates/etc/ferm/ferm.d/custom.conf.j2
+++ b/templates/etc/ferm/ferm.d/custom.conf.j2
@@ -1,0 +1,33 @@
+{#
+#    ==== Custom ip(6)tables rules for debops.ferm role ====
+#
+# You need to define 'item.dport: []' in your rule definition for debops.ferm
+# role to work correctly.
+#
+# Rules created by this template should be defined in ferm configuration
+# format, in 'item.rules' variable as YAML text block. See ferm(1) manual for
+# information abut ferm syntax.
+#
+# Remember that ferm by default configures both iptables and ip6tables at the
+# same time and write your rules accordingly. For example, put them in:
+#
+#   domain (ip ip6) table filter chain OUTPUT { }
+#
+# You can also use @if ferm function to specify only a particular domain:
+#
+#   @if @eq($DOMAIN, ip) { }
+#
+# To filter list of IP addresses for a particular domain, you can use
+# ipfilter() ferm function. See examples of dport_* rules for usage patterns.
+#
+#}
+# This file is managed by Ansible, all changes will be lost
+
+{% if item.by_role is defined and item.by_role %}
+# ip(6)tables rules defined by Ansible role: {{ item.by_role }}
+
+{% endif %}
+{% if item.rules is defined and item.rules %}
+{{ item.rules }}
+{% endif %}
+

--- a/templates/etc/ferm/filter-input.d/custom.conf.j2
+++ b/templates/etc/ferm/filter-input.d/custom.conf.j2
@@ -1,0 +1,34 @@
+{#
+#    ==== Custom ip(6)tables rules for debops.ferm role ====
+#
+# You need to define 'item.dport: []' in your rule definition for debops.ferm
+# role to work correctly.
+#
+# Rules created by this template should be defined in ferm configuration
+# format, in 'item.rules' variable as YAML text block. See ferm(1) manual for
+# information abut ferm syntax.
+#
+# Remember that ferm by default configures both iptables and ip6tables at the
+# same time and write your rules accordingly. All rules defined using this
+# template will be included inside:
+#
+#   domain (ip ip6) table filter chain INPUT { }
+#
+# You can use @if ferm function to specify only a particular domain:
+#
+#   @if @eq($DOMAIN, ip) { }
+#
+# To filter list of IP addresses for a particular domain, you can use
+# ipfilter() ferm function. See examples of dport_* rules for usage patterns.
+#
+#}
+# This file is managed by Ansible, all changes will be lost
+
+{% if item.by_role is defined and item.by_role %}
+# ip(6)tables rules defined by Ansible role: {{ item.by_role }}
+
+{% endif %}
+{% if item.rules is defined and item.rules %}
+{{ item.rules }}
+{% endif %}
+


### PR DESCRIPTION
You can now define custom ferm rules for either filter INPUT chain, or
all other chains as ferm configuration rules in a YAML text block and
pass them to 'debops.ferm' role using 'custom' rule type.
