### PR TITLE
Fix #12: JSON serialization-error in "Save ferm local facts".

### DIFF
--- a/templates/etc/ansible/facts.d/ferm.fact.j2
+++ b/templates/etc/ansible/facts.d/ferm.fact.j2
@@ -18,7 +18,7 @@
 {%     set _ = ferm_tpl_ansible_controllers.append(ansible_controller)                %}
 {%   endif                                                                            %}
 {% endif                                                                              %}
-{% set ferm_tpl_ansible_controllers_result = ferm_tpl_ansible_controllers | sort | unique %}
+{% set ferm_tpl_ansible_controllers_result = ferm_tpl_ansible_controllers | unique | sort %}
 {
 "ansible_controllers": {{ ferm_tpl_ansible_controllers_result | to_nice_json }}
 }


### PR DESCRIPTION
Make unique first, then sort. (And this is quicker, too).
