### PR TITLE
Per default skip running ferm in docker guests.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,6 +152,14 @@
     mode: '0644'
   notify: [ 'Reload sysctl' ]
 
+- name: Ensure that /etc/network/if-pre-up.d exists
+  file:
+    path: '/etc/network/if-pre-up.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
 - name: Configure forwarding in ifupdown if enabled
   template:
     src: 'etc/network/if-pre-up.d/ferm-forward.j2'


### PR DESCRIPTION
Note: `|bool` is required due to the deficits of jinja evaluation and
ansibles interpretation of results of jinja evaluation.