### PR TITLE
Support for restricted POSIX capabilities

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ ferm: True
 # iptables.
 ferm_flush: True
 
+# Force firewall configuration even if role thinks otherwise
+ferm_ignore_cap12s: False
+
 # List of iptables domains enabled in main ferm firewall
 # Currently supported domains:
 #   - 'ip'  - enables IPv4 support (iptables)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,5 +5,8 @@
 
 - name: Restart ferm
   service: name=ferm state=restarted
-  when: ferm is defined and ferm
+  when: (ferm and (ansible_local is undefined or
+         (ansible_local is defined and ansible_local.cap12s is undefined or
+          (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,8 +5,8 @@
 
 - name: Restart ferm
   service: name=ferm state=restarted
-  when: (ferm and (ansible_local is undefined or
+  when: (ferm and ((ansible_local is undefined or
          (ansible_local is defined and ansible_local.cap12s is undefined or
           (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
-           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))) or ferm_ignore_cap12s))
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,10 @@
     name: 'ferm'
     state: 'latest'
     install_recommends: 'no'
-  when: ferm
+  when: (ferm and (ansible_local is undefined or
+         (ansible_local is defined and ansible_local.cap12s is undefined or
+          (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
 
 - name: Create configuration directories
   file:
@@ -122,12 +125,18 @@
 - name: Apply iptables rules if ferm is enabled
   command: ferm --slow /etc/ferm/ferm.conf
   changed_when: False
-  when: ferm
+  when: (ferm and (ansible_local is undefined or
+         (ansible_local is defined and ansible_local.cap12s is undefined or
+          (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
 
 - name: Clear iptables rules if ferm is disabled
   command: ferm --flush /etc/ferm/ferm.conf
   changed_when: False
-  when: not ferm and ferm_flush
+  when: ((not ferm and ferm_flush) and (ansible_local is undefined or
+         (ansible_local is defined and ansible_local.cap12s is undefined or
+          (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
 
 - name: Configure sysctl
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,10 @@
     name: 'ferm'
     state: 'latest'
     install_recommends: 'no'
-  when: (ferm and (ansible_local is undefined or
+  when: (ferm and ((ansible_local is undefined or
          (ansible_local is defined and ansible_local.cap12s is undefined or
           (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
-           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))) or ferm_ignore_cap12s))
 
 - name: Create configuration directories
   file:
@@ -125,18 +125,18 @@
 - name: Apply iptables rules if ferm is enabled
   command: ferm --slow /etc/ferm/ferm.conf
   changed_when: False
-  when: (ferm and (ansible_local is undefined or
+  when: (ferm and ((ansible_local is undefined or
          (ansible_local is defined and ansible_local.cap12s is undefined or
           (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
-           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))) or ferm_ignore_cap12s))
 
 - name: Clear iptables rules if ferm is disabled
   command: ferm --flush /etc/ferm/ferm.conf
   changed_when: False
-  when: ((not ferm and ferm_flush) and (ansible_local is undefined or
+  when: ((not ferm and ferm_flush) and ((ansible_local is undefined or
          (ansible_local is defined and ansible_local.cap12s is undefined or
           (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
-           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))))
+           (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))) or ferm_ignore_cap12s))
 
 - name: Configure sysctl
   template:

--- a/templates/etc/network/if-pre-up.d/ferm-forward.j2
+++ b/templates/etc/network/if-pre-up.d/ferm-forward.j2
@@ -2,10 +2,10 @@
 
 # This file is managed by Ansible, all changes will be lost
 
-{% if (ferm and (ansible_local is undefined or
+{% if (ferm and ((ansible_local is undefined or
        (ansible_local is defined and ansible_local.cap12s is undefined or
         (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
-         (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list)))))) %}
+         (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))) or ferm_ignore_cap12s)) %}
 {% if ((ferm_forward is defined and ferm_forward) or
        ((ansible_local is defined and ansible_local) and
         (ansible_local.ferm is defined and ansible_local.ferm) and

--- a/templates/etc/network/if-pre-up.d/ferm-forward.j2
+++ b/templates/etc/network/if-pre-up.d/ferm-forward.j2
@@ -2,6 +2,10 @@
 
 # This file is managed by Ansible, all changes will be lost
 
+{% if (ferm and (ansible_local is undefined or
+       (ansible_local is defined and ansible_local.cap12s is undefined or
+        (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
+         (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list)))))) %}
 {% if ((ferm_forward is defined and ferm_forward) or
        ((ansible_local is defined and ansible_local) and
         (ansible_local.ferm is defined and ansible_local.ferm) and
@@ -34,5 +38,8 @@ fi
 {% endif %}
 {% else %}
 # Network forwarding in ip(6)tables is not enabled
+{% endif %}
+{% else %}
+# ferm support is disabled
 {% endif %}
 

--- a/templates/etc/sysctl.d/30-ferm.conf.j2
+++ b/templates/etc/sysctl.d/30-ferm.conf.j2
@@ -1,9 +1,9 @@
 # This file is managed by Ansible, all changes will be lost
 
-{% if (ferm and (ansible_local is undefined or
+{% if (ferm and ((ansible_local is undefined or
        (ansible_local is defined and ansible_local.cap12s is undefined or
         (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
-         (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list)))))) %}
+         (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list))))) or ferm_ignore_cap12s)) %}
 # Enable reverse path filtering
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1

--- a/templates/etc/sysctl.d/30-ferm.conf.j2
+++ b/templates/etc/sysctl.d/30-ferm.conf.j2
@@ -1,5 +1,9 @@
 # This file is managed by Ansible, all changes will be lost
 
+{% if (ferm and (ansible_local is undefined or
+       (ansible_local is defined and ansible_local.cap12s is undefined or
+        (ansible_local.cap12s is defined and (not ansible_local.cap12s.enabled or
+         (ansible_local.cap12s.enabled and 'cap_net_admin' in ansible_local.cap12s.list)))))) %}
 # Enable reverse path filtering
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1
@@ -22,4 +26,7 @@ net.ipv6.conf.all.accept_ra = 1
 {% else %}
 # Forwarding in ip(6)tables is not enabled
 
+{% endif %}
+{% else %}
+# ferm support is disabled
 {% endif %}


### PR DESCRIPTION
'debops.ferm' role will check if 'CAP_NET_ADMIN' capability is available
before configuring ip(6)tables. This functionality is optional and
requires additional local facts, gathered by a script which is available
in 'debops/debops-playbooks' repository.