### PR TITLE
Don't try to flush rules if ferm is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -129,7 +129,8 @@
 - name: Clear iptables rules if ferm is disabled
   command: ferm --flush /etc/ferm/ferm.conf
   changed_when: False
-  when: ((not ferm and ferm_flush) and (ferm_ignore_cap12s or (ansible_local|d() and ansible_local.cap12s|d() and
+  when: ((not ferm and ferm_flush) and (ansible_local|d() and ansible_local.ferm|d() and
+          ansible_local.ferm.enabled | bool) and (ferm_ignore_cap12s or (ansible_local|d() and ansible_local.cap12s|d() and
          (not ansible_local.cap12s.enabled or 'cap_net_admin' in ansible_local.cap12s.list))))
 
 - name: Configure sysctl

--- a/templates/etc/ansible/facts.d/ferm.fact.j2
+++ b/templates/etc/ansible/facts.d/ferm.fact.j2
@@ -27,6 +27,7 @@
 {% endif                                                                              %}
 {% set ferm_tpl_ansible_controllers_result = ferm_tpl_ansible_controllers | unique | sort %}
 {
+"enabled": "{{ ferm | bool | lower }}",
 "forward": "{{ ferm_tpl_forward }}",
 "ansible_controllers": {{ ferm_tpl_ansible_controllers_result | to_nice_json }}
 }


### PR DESCRIPTION
'debops.ferm' will now remember current enabled/disabled state in local
Ansible facts. This way if ferm might not be installed (because for
example, it never was enabled), role won't try and flush its rules
automatically.