### PR TITLE
Allow 'item.accept_any' to be toggleable

### DIFF
--- a/templates/etc/ferm/filter-input.d/dport_accept.conf.j2
+++ b/templates/etc/ferm/filter-input.d/dport_accept.conf.j2
@@ -29,7 +29,7 @@ protocol ({{ item.protocol | default(['tcp']) | join(' ') }}) dport ({{ item.dpo
 		saddr $ITEMS ACCEPT;
 	}
 {% else %}
-{% if item.accept_any is defined and item.accept_any %}
+{% if item.accept_any is defined and item.accept_any | bool %}
 	ACCEPT;
 {% else %}
 	# Connections from any IP address not allowed


### PR DESCRIPTION
Roles can specify 'item.accept_any' in ferm filter configuration as
a bool configurable from a variable.