### PR TITLE
Fix ferm enable/disable logic

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,7 @@
 
 - name: Restart ferm
   service: name=ferm state=restarted
-  when: (ferm and (ferm_ignore_cap12s or (ansible_local|d() and ansible_local.cap12s|d() and
-         (not ansible_local.cap12s.enabled or 'cap_net_admin' in ansible_local.cap12s.list))))
+  when: (ferm | bool and (ferm_ignore_cap12s | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+         (not ansible_local.cap12s.enabled | bool or
+          (ansible_local.cap12s.enabled | bool and 'cap_net_admin' in ansible_local.cap12s.list)))))
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,28 @@
 ---
 
+- name: Calculate debconf answer
+  set_fact:
+    ferm_register_debconf: |
+      {% if (ferm | bool and (ferm_ignore_cap12s | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+             (not ansible_local.cap12s.enabled | bool or
+              (ansible_local.cap12s.enabled | bool and 'cap_net_admin' in ansible_local.cap12s.list))))) %}
+      yes{% else %}no{% endif %}
+
 - name: Configure ferm status in debconf
   debconf:
     name: 'ferm'
     question: 'ferm/enable'
     vtype: 'boolean'
-    value: '{% if ferm %}yes{% else %}no{% endif %}'
+    value: '{{ ferm_register_debconf }}'
 
 - name: Ensure ferm is installed
   apt:
     name: 'ferm'
     state: 'latest'
     install_recommends: 'no'
-  when: (ferm and (ferm_ignore_cap12s or (ansible_local|d() and ansible_local.cap12s|d() and
-         (not ansible_local.cap12s.enabled or 'cap_net_admin' in ansible_local.cap12s.list))))
+  when: (ferm | bool and (ferm_ignore_cap12s | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+         (not ansible_local.cap12s.enabled | bool or
+          (ansible_local.cap12s.enabled | bool and 'cap_net_admin' in ansible_local.cap12s.list)))))
 
 - name: Create configuration directories
   file:
@@ -123,8 +132,9 @@
 - name: Apply iptables rules if ferm is enabled
   command: ferm --slow /etc/ferm/ferm.conf
   changed_when: False
-  when: (ferm and (ferm_ignore_cap12s or (ansible_local|d() and ansible_local.cap12s|d() and
-         (not ansible_local.cap12s.enabled or 'cap_net_admin' in ansible_local.cap12s.list))))
+  when: (ferm | bool and (ferm_ignore_cap12s | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+         (not ansible_local.cap12s.enabled | bool or
+          (ansible_local.cap12s.enabled | bool and 'cap_net_admin' in ansible_local.cap12s.list)))))
 
 - name: Clear iptables rules if ferm is disabled
   command: ferm --flush /etc/ferm/ferm.conf

--- a/templates/etc/default/ferm.j2
+++ b/templates/etc/default/ferm.j2
@@ -12,6 +12,11 @@ CACHE=no
 OPTIONS=
 
 # Enable the ferm init script? (i.e. run on bootup)
-ENABLED="{% if ferm is defined and ferm %}yes{% else %}no{% endif %}"
-
+{% if (ferm | bool and (ferm_ignore_cap12s | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+       (not ansible_local.cap12s.enabled | bool or
+        (ansible_local.cap12s.enabled | bool and 'cap_net_admin' in ansible_local.cap12s.list))))) %}
+ENABLED="yes"
+{% else %}
+ENABLED="no"
+{% endif %}
 

--- a/templates/etc/network/if-pre-up.d/ferm-forward.j2
+++ b/templates/etc/network/if-pre-up.d/ferm-forward.j2
@@ -2,8 +2,9 @@
 
 # This file is managed by Ansible, all changes will be lost
 
-{% if (ferm and (ferm_ignore_cap12s or (ansible_local|d() and ansible_local.cap12s|d() and
-       (not ansible_local.cap12s.enabled or 'cap_net_admin' in ansible_local.cap12s.list)))) %}
+{% if (ferm | bool and (ferm_ignore_cap12s | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+       (not ansible_local.cap12s.enabled | bool or
+        (ansible_local.cap12s.enabled | bool and 'cap_net_admin' in ansible_local.cap12s.list))))) %}
 {% if ((ferm_forward is defined and ferm_forward) or
        ((ansible_local is defined and ansible_local) and
         (ansible_local.ferm is defined and ansible_local.ferm) and

--- a/templates/etc/sysctl.d/30-ferm.conf.j2
+++ b/templates/etc/sysctl.d/30-ferm.conf.j2
@@ -1,7 +1,8 @@
 # This file is managed by Ansible, all changes will be lost
 
-{% if (ferm and (ferm_ignore_cap12s or (ansible_local|d() and ansible_local.cap12s|d() and
-       (not ansible_local.cap12s.enabled or 'cap_net_admin' in ansible_local.cap12s.list)))) %}
+{% if (ferm | bool and (ferm_ignore_cap12s | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+       (not ansible_local.cap12s.enabled | bool or
+        (ansible_local.cap12s.enabled | bool and 'cap_net_admin' in ansible_local.cap12s.list))))) %}
 # Enable reverse path filtering
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1


### PR DESCRIPTION
'debops.ferm' will now correctly enable or disable ferm on hosts without
POSIX capabilities enabled. Additionally, ferm status is debconf is
correctly set and synchronized with the configuration file.