### PR TITLE
Fix: Task "Configure forwarding in ifupdown if enabled" fails

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,6 +152,14 @@
     mode: '0644'
   notify: [ 'Reload sysctl' ]
 
+- name: Ensure that /etc/network/if-pre-up.d exists
+  file:
+    path: '/etc/network/if-pre-up.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
 - name: Configure forwarding in ifupdown if enabled
   template:
     src: 'etc/network/if-pre-up.d/ferm-forward.j2'


### PR DESCRIPTION
Fails is /etc/network/if-pre-up.d does not exists, e.g. if
this role is used without using debops.ifupdown before.