### PR TITLE
Use the 'ferm' value for 'ferm_flush'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ ferm: True
 # true, but you may need set both `ferm` and this to ``False`` if you
 # are running in some container and are not allowed to change
 # iptables.
-ferm_flush: True
+ferm_flush: '{{ ferm | bool }}'
 
 # List of additional packages to install with ferm
 ferm_packages: []


### PR DESCRIPTION
By default 'ferm' and 'ferm_flush' variables should be either both
enabled or both disabled.

Fixes #38