### PR TITLE
Allow to specify in-interface and out-interface for rules of type 'chain'.

### DIFF
--- a/templates/etc/ferm/ferm.d/chain.conf.j2
+++ b/templates/etc/ferm/ferm.d/chain.conf.j2
@@ -50,18 +50,20 @@
 List of parameters:
 
 Required:
-  item.chain       name of the chain to create
+  item.chain         name of the chain to create
 
 Optional:
-  item.table       specify which table to add rules into
-  item.dport       list of destination ports to configure
-  item.protocol(s) list of protocols to configure (tcp, udp)
-  item.saddr       list of source addresses to accept
-  item.accept_any  accept connections from any IP address if True
-  item.disabled    if True, disable the rule (can be used to toggle rule via variable)
-  item.enabled     if True, enable the rule (can be used to toggle rule via variable)
-  item.include     include custom file or command output
-  item.jump        jump tp specified chain
+  item.table         specify which table to add rules into
+  item.dport         list of destination ports to configure
+  item.protocol(s)   list of protocols to configure (tcp, udp)
+  item.saddr         list of source addresses to accept
+  item.in_interface  list of name of an interface via which a packet was received
+  item.out_interface list of name of an interface via which a packet is going to be sent
+  item.accept_any    accept connections from any IP address if True
+  item.disabled      if True, disable the rule (can be used to toggle rule via variable)
+  item.enabled       if True, enable the rule (can be used to toggle rule via variable)
+  item.include       include custom file or command output
+  item.jump          jump tp specified chain
 
 #}
 
@@ -70,7 +72,14 @@ domain $domains table {{ item.table | default('filter') }} chain "{{ item.chain 
 {% if item.saddr is defined and item.saddr %}
     @def $ITEMS = ( @ipfilter( ({{ item.saddr | unique | join(" ") }}) ) );
     @if @ne($ITEMS,"") {
-        saddr $ITEMS ACCEPT;
+        saddr $ITEMS
+{% if item.in_interface|d() %}
+        interface {{ item.in_interface }}
+{% endif %}
+{% if item.out_interface|d() %}
+        outerface {{ item.out_interface }}
+{% endif %}
+        ACCEPT;
     }
 {% else %}
 {% if item.accept_any is defined and item.accept_any | bool %}

--- a/templates/etc/ferm/ferm.d/chain.conf.j2
+++ b/templates/etc/ferm/ferm.d/chain.conf.j2
@@ -57,8 +57,8 @@ Optional:
   item.dport         list of destination ports to configure
   item.protocol(s)   list of protocols to configure (tcp, udp)
   item.saddr         list of source addresses to accept
-  item.in_interface  list of name of an interface via which a packet was received
-  item.out_interface list of name of an interface via which a packet is going to be sent
+  item.interface     list of name of an interface via which a packet was received
+  item.outerface     list of name of an interface via which a packet is going to be sent
   item.accept_any    accept connections from any IP address if True
   item.disabled      if True, disable the rule (can be used to toggle rule via variable)
   item.enabled       if True, enable the rule (can be used to toggle rule via variable)
@@ -73,11 +73,15 @@ domain $domains table {{ item.table | default('filter') }} chain "{{ item.chain 
     @def $ITEMS = ( @ipfilter( ({{ item.saddr | unique | join(" ") }}) ) );
     @if @ne($ITEMS,"") {
         saddr $ITEMS
-{% if item.in_interface|d() %}
-        interface {{ item.in_interface }}
+{% if item.interface|d() and item.interface is string %}
+        interface {{ item.interface }}
+{% elif item.interface|d() and item.interface is iterable %}
+        interface ({{ item.interface | unique | join(' ') }})
 {% endif %}
-{% if item.out_interface|d() %}
-        outerface {{ item.out_interface }}
+{% if item.outerface|d() and item.outerface is string %}
+        outerface {{ item.outerface }}
+{% elif item.outerface|d() and item.outerface is iterable %}
+        outerface ({{ item.outerface | unique | join(' ') }})
 {% endif %}
         ACCEPT;
     }

--- a/templates/etc/ferm/ferm.d/chain.conf.j2
+++ b/templates/etc/ferm/ferm.d/chain.conf.j2
@@ -50,37 +50,37 @@
 List of parameters:
 
 Required:
-  item.chain		name of the chain to create
+  item.chain       name of the chain to create
 
 Optional:
-  item.table		specify which table to add rules into
-  item.dport		list of destination ports to configure
-  item.protocol(s)	list of protocols to configure (tcp, udp)
-  item.saddr		list of source addresses to accept
-  item.accept_any	accept connections from any IP address if True
-  item.disabled		if True, disable the rule (can be used to toggle rule via variable)
-  item.enabled		if True, enable the rule (can be used to toggle rule via variable)
-  item.include          include custom file or command output
-  item.jump		jump tp specified chain
+  item.table       specify which table to add rules into
+  item.dport       list of destination ports to configure
+  item.protocol(s) list of protocols to configure (tcp, udp)
+  item.saddr       list of source addresses to accept
+  item.accept_any  accept connections from any IP address if True
+  item.disabled    if True, disable the rule (can be used to toggle rule via variable)
+  item.enabled     if True, enable the rule (can be used to toggle rule via variable)
+  item.include     include custom file or command output
+  item.jump        jump tp specified chain
 
 #}
 
 {% if ferm_tpl_state == 'enabled' %}
 domain $domains table {{ item.table | default('filter') }} chain "{{ item.chain }}"{% if ferm_tpl_protocol or item.dport|d() %} protocol ({{ (ferm_tpl_protocol if ferm_tpl_protocol else ['tcp']) | join(' ') }}){% endif %}{% if item.dport|d() %} dport ({{ item.dport | join(' ') }}){% endif %} {
 {% if item.saddr is defined and item.saddr %}
-	@def $ITEMS = ( @ipfilter( ({{ item.saddr | unique | join(" ") }}) ) );
-	@if @ne($ITEMS,"") {
-		saddr $ITEMS ACCEPT;
-	}
+    @def $ITEMS = ( @ipfilter( ({{ item.saddr | unique | join(" ") }}) ) );
+    @if @ne($ITEMS,"") {
+        saddr $ITEMS ACCEPT;
+    }
 {% else %}
 {% if item.accept_any is defined and item.accept_any | bool %}
-	ACCEPT;
+    ACCEPT;
 {% elif item.include is defined and item.include %}
-	@include "{{ item.include }}";
+    @include "{{ item.include }}";
 {% elif item.jump is defined and item.jump %}
-	jump "{{ item.jump }}";
+    jump "{{ item.jump }}";
 {% else %}
-	# Connections from any IP address not allowed
+    # Connections from any IP address not allowed
 {% endif %}
 {% endif %}
 }


### PR DESCRIPTION
Example configuration:

```YAML
ferm_host_rules:
  - type: 'chain'
    name: 'vpn'
    table: 'nat'
    chain: 'POSTROUTING'
    saddr: [ '192.168.254.0/24' ]
    jump: 'MASQUERADE'
    out_interface: 'eth0'
```