### PR TITLE
restart fail2ban on ferm flush rules

### DIFF
--- a/templates/etc/ferm/ferm.d/fail2ban.conf.j2
+++ b/templates/etc/ferm/ferm.d/fail2ban.conf.j2
@@ -6,6 +6,7 @@
 {% endif %}
 {% if item.when is undefined or item.when | bool %}
 @hook post "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
+@hook flush "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
 {% else %}
 # Rule disabled by 'item.when' condition
 {% endif %}


### PR DESCRIPTION
I think fail2ban is independent of ferm so fail2ban should be restarted when ferm is stop.