### PR TITLE
Restart ferm only when configuration changes are made

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
     - '{{ ferm_host_custom_files }}'
   when: ((item.src is defined or item.content is defined) and
          item.dest is defined)
+  notify: [ 'Restart ferm' ]
   tags: [ 'role::ferm:custom_files' ]
 
 - name: Configure ferm default variables
@@ -75,6 +76,7 @@
     - '{{ ferm_default_rules }}'
   when: (ferm_enabled|bool and (item.type is defined and item.type) and
          (item.delete is defined and item.delete | bool))
+  notify: [ 'Restart ferm' ]
   tags: [ 'role::ferm:rules' ]
 
 - name: Configure ip(6)tables rules
@@ -92,6 +94,7 @@
     - '{{ ferm_default_rules }}'
   when: (ferm_enabled|bool and (item.type is defined and item.type) and
          (item.delete is undefined or not item.delete | bool))
+  notify: [ 'Restart ferm' ]
   tags: [ 'role::ferm:rules' ]
 
 - name: Remove iptables INPUT rules if requested
@@ -105,6 +108,7 @@
     - '{{ ferm_input_dependent_list }}'
   when: (ferm_enabled|bool and (item.type is defined and item.type) and
          (item.delete is defined and item.delete | bool))
+  notify: [ 'Restart ferm' ]
   tags: [ 'role::ferm:rules' ]
 
 - name: Configure iptables INPUT rules
@@ -121,14 +125,11 @@
     - '{{ ferm_input_dependent_list }}'
   when: (ferm_enabled|bool and (item.type is defined and item.type) and
          (item.delete is undefined or not item.delete | bool))
+  notify: [ 'Restart ferm' ]
   tags: [ 'role::ferm:rules' ]
 
-- name: Apply iptables rules if ferm is enabled
-  service:
-    name: 'ferm'
-    state: 'restarted'
-  changed_when: False
-  when: ferm_enabled | bool
+- name: Flush handlers to restart ferm if changes were made
+  meta: flush_handlers
   tags: [ 'role::ferm:rules' ]
 
 - name: Clear iptables rules if ferm is disabled

--- a/templates/etc/ferm/ferm.d/fail2ban.conf.j2
+++ b/templates/etc/ferm/ferm.d/fail2ban.conf.j2
@@ -6,6 +6,7 @@
 {% endif %}
 {% if item.when is undefined or item.when | bool %}
 @hook post "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
+@hook flush "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
 {% else %}
 # Rule disabled by 'item.when' condition
 {% endif %}


### PR DESCRIPTION
Currently the role restarts ferm on every single run. This does an iptables-save/restore and ferm does not restore counters, so every iptables counter will be reset to 0. 

This commit just uses the handler that is already in place to restart ferm upon changes, instead of performing a restart every time the role runs regardless of change states.