### PR TITLE
add simple masquerading template

### DIFF
--- a/templates/etc/ferm/ferm.d/masquerade.conf.j2
+++ b/templates/etc/ferm/ferm.d/masquerade.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 {#
-  marsquerade - add masquerading rules     
+  marsquerade - add masquerading rules
 
 List of parameters:
 

--- a/templates/etc/ferm/ferm.d/masquerading.conf.j2
+++ b/templates/etc/ferm/ferm.d/masquerading.conf.j2
@@ -1,0 +1,39 @@
+# {{ ansible_managed }}
+
+{#
+  marsquerade - add masquerading rules     
+
+List of parameters:
+
+Required:
+  item.outerface          Public interface to Masquerade the forwarding network
+
+#}
+{# Rule arguments #}
+{# ============== #}
+{% set ferm_tpl_outerface = [] %}
+{% if item.outerface is defined and item.outerface %}
+{% if item.outerface is string %}
+{% set _ = ferm_tpl_outerface.append(item.outerface) %}
+{% else %}
+{% set ferm_tpl_outerface = item.outerface %}
+{% endif %}
+{% endif %}
+{# Main template #}
+{# ============= #}
+{% if item.comment|d() %}
+# {{ item.comment }}
+
+{% endif %}
+
+{% if ferm_tpl_outerface %}
+table nat {
+	chain POSTROUTING {
+		outerface {{ ferm_tpl_outerface | unique | join(" ") }} MASQUERADE;	
+	}
+}
+
+{% else %}
+# Cannot configure DMZ, public or private IP addresses not specified
+{% endif %}
+


### PR DESCRIPTION
This template procure a really simple masquerading rule. 
It can/should be improve with: 
 - (s/d)addr 
 - to-ports port:port (random)