### PR TITLE
Renamed `ferm_.*rules` to `ferm__.*rules` and `ferm_forward` to `ferm__forward`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ v0.1.6
   undefined. This will ensure that the role works on hosts which don't have it
   applied yet. [drybjed]
 
+- Renamed ``ferm_.*rules`` to ``ferm__.*rules`` and ``ferm_forward`` to ``ferm__forward``.
+  Old names are currently still supported to not break stuff while updating the
+  code which depends on the old names. [ypid]
+
 v0.1.5
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,13 +102,13 @@ ferm_log_group: '32'
 # transition to the new firewall rules in the future.
 ferm_include_legacy: True
 
-# List of iptables rules to manage, templates used by these rules are included
-# in templates/etc/ferm/ferm.d/ directory.
+# List of ``iptables`` rules to manage, templates used by these rules are included
+# in :file:`templates/etc/ferm/ferm.d/` directory.
 # Additional variables are described below.
-ferm_rules: []
-ferm_group_rules: []
-ferm_host_rules: []
-ferm_dependent_rules: []
+ferm__rules: []
+ferm__group_rules: []
+ferm__host_rules: []
+ferm__dependent_rules: []
 
 # List of iptables INPUT rules to manage, many variables can be found in
 # template files, located in templates/etc/ferm/filter-input.d/ directory.
@@ -145,7 +145,7 @@ ferm_weight_map:
   'any-reject': '99'
 
 # List of default firewall rules defined on each host
-ferm_default_rules: '{{ ferm_rules_default_policy +
+ferm__default_rules: '{{ ferm_rules_default_policy +
                         ferm_rules_log +
                         ferm_rules_hooks +
                         ferm_rules_variables +
@@ -366,10 +366,10 @@ ferm_rules_forward:
     role_weight: '10'
     name: 'external_in'
     comment: 'Forward incoming traffic to other hosts'
-    when: '{{ (ferm_forward | bool or
+    when: '{{ ((ferm__forward|d(ferm_forward) | bool) or
                (ansible_local|d() and ansible_local.ferm|d() and
                 ansible_local.ferm.forward | bool)) }}'
-    delete: '{{ (not ferm_forward | bool and
+    delete: '{{ (not (ferm__forward|d(ferm_forward) | bool) and
                  (ansible_local|d(True) and (ansible_local.ferm is undefined or
                    (ansible_local.ferm.forward is undefined or
                     not ansible_local.ferm.forward | bool)))) }}'
@@ -382,10 +382,10 @@ ferm_rules_forward:
     role_weight: '20'
     name: 'external_out'
     comment: 'Forward outgoing traffic to other hosts'
-    when: '{{ (ferm_forward | bool or
+    when: '{{ ((ferm__forward|d(ferm_forward) | bool) or
                (ansible_local|d() and ansible_local.ferm|d() and
                 ansible_local.ferm.forward | bool)) }}'
-    delete: '{{ (not ferm_forward | bool and
+    delete: '{{ (not (ferm__forward|d(ferm_forward) | bool) and
                  (ansible_local|d(True) and (ansible_local.ferm is undefined or
                    (ansible_local.ferm.forward is undefined or
                     not ansible_local.ferm.forward | bool)))) }}'
@@ -399,10 +399,10 @@ ferm_rules_forward:
     role_weight: '30'
     name: 'internal'
     comment: 'Forward internal traffic between hosts'
-    when: '{{ (ferm_forward | bool or
+    when: '{{ ((ferm__forward|d(ferm_forward) | bool) or
                (ansible_local|d() and ansible_local.ferm|d() and
                 ansible_local.ferm.forward | bool)) }}'
-    delete: '{{ (not ferm_forward | bool and
+    delete: '{{ (not (ferm__forward|d(ferm_forward) | bool) and
                  (ansible_local|d(True) and (ansible_local.ferm is undefined or
                    (ansible_local.ferm.forward is undefined or
                     not ansible_local.ferm.forward | bool)))) }}'
@@ -413,15 +413,19 @@ ferm_custom_files: []
 ferm_group_custom_files: []
 ferm_host_custom_files: []
 
-# Enable or disable fail2ban integration. ``ferm`` will send ``fail2ban`` a reload
+# Enable or disable ``fail2ban`` integration. ``ferm`` will send ``fail2ban`` a reload
 # command after its own configuration is reloaded. If ``fail2ban`` is not present
 # or turned off, nothing will happen.
 ferm_fail2ban: True
 
-# Enable forwarding in ip(6)tables. This option can be used by other roles and
-# its status is saved in Ansible local facts, which will override variable
+
+# .. envvar:: ferm__forward
+#
+# Enable forwarding in ``ip(6)tables``. This option can be used by other roles and
+# it's status is saved in Ansible local facts, which will override variable
 # status from role defaults or inventory.
-ferm_forward: False
+ferm__forward: False
+
 
 # List of interfaces that are connected to external network, traffic on these
 # interfaces will be forwarded to all hosts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,11 +72,16 @@
     path: '/etc/ferm/ferm.d/{{ ferm_weight_map[item.weight_class|d()] | d(item.weight | d(ferm_default_weight)) }}_{{ item.filename | d(((item.role + "_" + ((item.role_weight + "_") if item.role_weight|d() else "")) if item.role|d() else "") + item.type + "_" + item.name | d((item.dport[0] if item.dport|d() else "rules"))) }}.conf'
     state: 'absent'
   with_flattened:
-    - '{{ ferm_rules }}'
-    - '{{ ferm_group_rules }}'
-    - '{{ ferm_host_rules }}'
-    - '{{ ferm_dependent_rules }}'
-    - '{{ ferm_default_rules }}'
+    - '{{ ferm_rules           | d([]) | list }}'
+    - '{{ ferm_group_rules     | d([]) | list }}'
+    - '{{ ferm_host_rules      | d([]) | list }}'
+    - '{{ ferm_dependent_rules | d([]) | list }}'
+    - '{{ ferm_default_rules   | d([]) | list }}'
+    - '{{ ferm__rules }}'
+    - '{{ ferm__group_rules }}'
+    - '{{ ferm__host_rules }}'
+    - '{{ ferm__dependent_rules }}'
+    - '{{ ferm__default_rules }}'
   when: (ferm_enabled|bool and item.type|d() and (item.delete|d() | bool))
   register: ferm_register_rules_del
   tags: [ 'role::ferm:rules' ]
@@ -89,11 +94,16 @@
     group: 'adm'
     mode: '0644'
   with_flattened:
-    - '{{ ferm_rules }}'
-    - '{{ ferm_group_rules }}'
-    - '{{ ferm_host_rules }}'
-    - '{{ ferm_dependent_rules }}'
-    - '{{ ferm_default_rules }}'
+    - '{{ ferm_rules           | d([]) | list }}'
+    - '{{ ferm_group_rules     | d([]) | list }}'
+    - '{{ ferm_host_rules      | d([]) | list }}'
+    - '{{ ferm_dependent_rules | d([]) | list }}'
+    - '{{ ferm_default_rules   | d([]) | list }}'
+    - '{{ ferm__rules }}'
+    - '{{ ferm__group_rules }}'
+    - '{{ ferm__host_rules }}'
+    - '{{ ferm__dependent_rules }}'
+    - '{{ ferm__default_rules }}'
   when: (ferm_enabled|bool and item.type|d() and not (item.delete|d() | bool))
   register: ferm_register_rules_add
   tags: [ 'role::ferm:rules' ]

--- a/templates/etc/ansible/facts.d/ferm.fact.j2
+++ b/templates/etc/ansible/facts.d/ferm.fact.j2
@@ -1,5 +1,5 @@
 {% set ferm_tpl_forward = False                                                       %}
-{% if ((ferm_forward|d()) or
+{% if ((ferm__forward|d(ferm_forward) | bool) or
        (ansible_local|d() and ansible_local.ferm|d() and
         (ansible_local.ferm.forward|d() | bool)))                                     %}
 {%   set ferm_tpl_forward = True                                                      %}

--- a/templates/etc/ansible/facts.d/ferm.fact.j2
+++ b/templates/etc/ansible/facts.d/ferm.fact.j2
@@ -1,8 +1,7 @@
 {% set ferm_tpl_forward = False                                                       %}
-{% if ((ferm_forward is defined and ferm_forward) or
-       ((ansible_local is defined and ansible_local) and
-        (ansible_local.ferm is defined and ansible_local.ferm) and
-        (ansible_local.ferm.forward is defined and ansible_local.ferm.forward | bool))) %}
+{% if ((ferm_forward|d()) or
+       (ansible_local|d() and ansible_local.ferm|d() and
+        (ansible_local.ferm.forward|d() | bool)))                                     %}
 {%   set ferm_tpl_forward = True                                                      %}
 {% endif                                                                              %}
 {% set ferm_tpl_hooks = ferm_init_hooks | bool %}
@@ -11,29 +10,28 @@
 {%   set ferm_tpl_hooks = ansible_local.ferm.hooks %}
 {% endif %}
 {% set ferm_tpl_ansible_controllers = []                                              %}
-{% if (ansible_local is defined and ansible_local) and
-      (ansible_local.ferm is defined and ansible_local.ferm) and
-      (ansible_local.ferm.ansible_controllers is defined and ansible_local.ferm.ansible_controllers) %}
+{% if ansible_local|d() and ansible_local.ferm|d() and
+      ansible_local.ferm.ansible_controllers|d() %}
 {%   for element in ansible_local.ferm.ansible_controllers                            %}
 {%     set _ = ferm_tpl_ansible_controllers.append(element)                           %}
 {%   endfor                                                                           %}
 {% endif                                                                              %}
-{% if ferm_ansible_controllers is defined and ferm_ansible_controllers                %}
+{% if ferm_ansible_controllers|d()                                                    %}
 {%   for element in ferm_ansible_controllers                                          %}
 {%     if element not in ferm_tpl_ansible_controllers                                 %}
 {%       set _ = ferm_tpl_ansible_controllers.append(element)                         %}
 {%     endif                                                                          %}
 {%   endfor                                                                           %}
 {% endif                                                                              %}
-{% if ansible_controller is defined and ansible_controller                            %}
+{% if ansible_controller|d()                                                          %}
 {%   if ansible_controller not in ferm_tpl_ansible_controllers                        %}
 {%     set _ = ferm_tpl_ansible_controllers.append(ansible_controller)                %}
 {%   endif                                                                            %}
 {% endif                                                                              %}
 {% set ferm_tpl_ansible_controllers_result = ferm_tpl_ansible_controllers | unique | sort %}
 {
-"enabled": "{{ ferm_enabled | bool | lower }}",
-"forward": "{{ ferm_tpl_forward }}",
-"hooks": "{{ ferm_tpl_hooks | bool | lower }}",
+"enabled": "{{ ferm_enabled     | bool | lower }}",
+"forward": "{{ ferm_tpl_forward | bool | lower }}",
+"hooks":   "{{ ferm_tpl_hooks   | bool | lower }}",
 "ansible_controllers": {{ ferm_tpl_ansible_controllers_result | to_nice_json }}
 }

--- a/templates/etc/network/if-pre-up.d/ferm-forward.j2
+++ b/templates/etc/network/if-pre-up.d/ferm-forward.j2
@@ -3,7 +3,7 @@
 # {{ ansible_managed }}
 
 {% if ferm_enabled | bool %}
-{%   if ferm_forward|d() or
+{%   if (ferm__forward|d(ferm_forward) | bool) or
        (ansible_local|d() and ansible_local.ferm|d() and
         (ansible_local.ferm.forward|d() | bool)) %}
 {%     set ferm_tpl_interfaces = (ferm_external_interfaces|d([]) | list) +

--- a/templates/etc/sysctl.d/30-ferm.conf.j2
+++ b/templates/etc/sysctl.d/30-ferm.conf.j2
@@ -5,7 +5,7 @@
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1
 
-{%   if ((ferm_forward|d()) or
+{%   if ((ferm__forward|d(ferm_forward) | bool) or
          (ansible_local|d() and ansible_local.ferm|d() and (ansible_local.ferm.forward|d() | bool))) %}
 # Enable IPv4 forwarding
 net.ipv4.ip_forward = 1

--- a/templates/etc/sysctl.d/30-ferm.conf.j2
+++ b/templates/etc/sysctl.d/30-ferm.conf.j2
@@ -5,10 +5,8 @@
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1
 
-{% if ((ferm_forward is defined and ferm_forward) or
-       ((ansible_local is defined and ansible_local) and
-        (ansible_local.ferm is defined and ansible_local.ferm) and
-        (ansible_local.ferm.forward is defined and ansible_local.ferm.forward | bool))) %}
+{%   if ((ferm_forward|d()) or
+         (ansible_local|d() and ansible_local.ferm|d() and (ansible_local.ferm.forward|d() | bool))) %}
 # Enable IPv4 forwarding
 net.ipv4.ip_forward = 1
 
@@ -20,10 +18,10 @@ net.ipv6.conf.all.forwarding = 1
 net.ipv6.conf.default.accept_ra = 1
 net.ipv6.conf.all.accept_ra = 1
 
-{% else %}
+{%   else %}
 # Forwarding in ip(6)tables is not enabled
 
-{% endif %}
+{%   endif %}
 {% else %}
 # ferm support is disabled
 {% endif %}


### PR DESCRIPTION
Old names are currently still supported to not break stuff while updating the code which depends on the old names.