### PR TITLE
Reject other IPv6 protocols in reject rules

### DIFF
--- a/templates/etc/ferm/ferm.d/reject.conf.j2
+++ b/templates/etc/ferm/ferm.d/reject.conf.j2
@@ -79,6 +79,9 @@
     @if @eq($DOMAIN, ip) {
         REJECT reject-with icmp-proto-unreachable;
     }
+    @if @eq($DOMAIN, ip6) {
+        REJECT;
+    }
 }
 {% else %}
 # Rule disabled by 'item.when' condition


### PR DESCRIPTION
Reject rules have let through other protocols than TCP or UDP for IPv6.
These were already rejected for IPv4. This commit adds a similar rule
for IPv6 which rejects with adm-prohibited.

Fixes #105.