### PR TITLE
DROP rate limited packets

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -459,7 +459,7 @@ ferm__rules_filter_icmp:
     hashlimit_burst: '{{ ferm__filter_icmp_burst }}'
     hashlimit_expire: '{{ ferm__filter_icmp_expire }}'
     hashlimit_target: 'ACCEPT'
-    target: 'REJECT'
+    target: 'DROP'
 
                                                                    # ]]]
 # .. envvar:: ferm__rules_filter_conntrack [[[
@@ -489,7 +489,7 @@ ferm__rules_filter_syn:
     hashlimit_burst: '{{ ferm__filter_syn_burst }}'
     hashlimit_expire: '{{ ferm__filter_syn_expire }}'
     hashlimit_target: 'RETURN'
-    target: 'REJECT'
+    target: 'DROP'
 
                                                                    # ]]]
 # .. envvar:: ferm__rules_filter_recent_badguys [[[


### PR DESCRIPTION
If packets are rate limited is does not make much sense to reject them.
As we don't want these packets, just drop them.

Fixes #102.