### PR TITLE
Fix for accept template. Fix hashlimit default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,7 +152,7 @@ ferm__filter_syn_limit: '40/second'
 # .. envvar:: ferm__filter_syn_burst [[[
 #
 # Burst limit when filtering TCP SYN segments.
-ferm__filter_syn_burst: '20'
+ferm__filter_syn_burst: '40'
 
                                                                    # ]]]
 # .. envvar:: ferm__filter_syn_expire [[[

--- a/templates/etc/ferm/ferm.d/accept.conf.j2
+++ b/templates/etc/ferm/ferm.d/accept.conf.j2
@@ -280,6 +280,9 @@
 {%     endif %}
 {%   endif %}
 {% endif %}
+{% if ferm__tpl_daddr %}
+{%   set _= ferm__tpl_arguments.append("daddr (" + ferm__tpl_daddr | join(" ") +")") %}
+{% endif %}
 {% if ferm__tpl_state %}
 {%   if ferm__tpl_state | length == 1 %}
 {%     set _ = ferm__tpl_arguments.append("mod state state " +  ferm__tpl_state | join(" ")) %}


### PR DESCRIPTION
Rules destination rules now created with accept template.
The haslimit default leads to an error on most recent versions, tested with debian strech, recent iptables(v1.6.0)/kernel(4.9.2-2). This leads to ferm failing with dmesg messge: overflow, try lower: 25000/20. see http://lxr.free-electrons.com/source/net/netfilter/xt_hashlimit.c.

Sorry for the same commit message the second one should be: 
fixed default, breaks with recent iptables(v1.6.0)/kernel(4.9.2-2). error xt_hashlimit: overflow, try lower: 25000/20