### PR TITLE
Fix AttributeError in Python 3

### DIFF
--- a/templates/lookup/ferm__fix_dependent_rules.j2
+++ b/templates/lookup/ferm__fix_dependent_rules.j2
@@ -30,7 +30,7 @@
 {%     endfor %}
 {%   endif %}
 {% endif %}
-{% for key, value in ferm__tpl_fixed_rules.iteritems() %}
+{% for key, value in ferm__tpl_fixed_rules.items() %}
 {%   set _ = ferm__tpl_flattened_rules.append(value) %}
 {% endfor %}
 {{ ferm__tpl_flattened_rules | to_json }}


### PR DESCRIPTION
Python 3 has no `.iteritems()`. This should not impact performance on Python 2 too heavily.