### PR TITLE
Restart fail2ban using systemd condrestart

### DIFF
--- a/templates/etc/ferm/ferm.d/fail2ban.conf.j2
+++ b/templates/etc/ferm/ferm.d/fail2ban.conf.j2
@@ -5,8 +5,8 @@
 
 {% endif %}
 {% if item.when is undefined or item.when | bool %}
-@hook post "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
-@hook flush "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
+@hook post "/bin/systemctl condrestart fail2ban.service";
+@hook flush "/bin/systemctl condrestart fail2ban.service";
 {% else %}
 # Rule disabled by 'item.when' condition
 {% endif %}


### PR DESCRIPTION
The previous code does two things:

1. Restart fail2ban ONLY if it's running with `fail2ban-client ping`
2. Re-add the fail2ban chain that was removed due to the ferm restart using `fail2ban-client`

However, using `fail2ban-client reload` does not re-add the `f2b-*` chains for me. MRE:

```
~# iptables -nvL | grep f2b
   15  1124 f2b-sshd   tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            multiport dports 22
Chain f2b-sshd (1 references)
~# systemctl start ferm
~# iptables -nvL | grep f2b
~# fail2ban-client reload
OK
~# iptables -nvL | grep f2b
```

Restarting the fail2ban service does re-add these chains:

```
~# systemctl restart fail2ban
~# iptables -nvL | grep f2b
    3   236 f2b-sshd   tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            multiport dports 22
Chain f2b-sshd (1 references)
```

Aside from this, the current `fail2ban-client ping` logic can be simplified by using systemd `condrestart`, which restarts the service only when it's running. This does mean that this commit assumes fail2ban runs as a systemd service.

I do not use your project, so I am not interested in maintaining or updating this PR. In case losing support for non-systemd systems is unacceptable, feel free to close it.